### PR TITLE
Refactor: #3 Modify JWT에 userId를 포함하여 사용자 식별 개선

### DIFF
--- a/src/main/java/com/matzip/api/matzip_api/global/auth/domain/CustomUserDetails.java
+++ b/src/main/java/com/matzip/api/matzip_api/global/auth/domain/CustomUserDetails.java
@@ -13,7 +13,9 @@ public class CustomUserDetails implements UserDetails {
     public CustomUserDetails(User user) {
         this.user = user;
     }
-
+    public Long getUserId() {
+        return user.getId();
+    }
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return new ArrayList<>();

--- a/src/main/java/com/matzip/api/matzip_api/global/auth/filter/JwtFilter.java
+++ b/src/main/java/com/matzip/api/matzip_api/global/auth/filter/JwtFilter.java
@@ -46,9 +46,11 @@ public class JwtFilter extends OncePerRequestFilter {
             }
 
             String username = tokenManager.getUsername(accessToken);
+            Long userId = tokenManager.getUserId(accessToken);
 
             //userEntity를 생성하여 값 set
             User user = User.builder()
+                .id(userId)
                 .account(username)
                 .password("temp")
                 .build();

--- a/src/main/java/com/matzip/api/matzip_api/global/auth/filter/LoginFilter.java
+++ b/src/main/java/com/matzip/api/matzip_api/global/auth/filter/LoginFilter.java
@@ -78,7 +78,8 @@ public class LoginFilter extends AbstractAuthenticationProcessingFilter {
 
         CustomUserDetails customUserDetails = (CustomUserDetails) authResult.getPrincipal();
         String username = customUserDetails.getUsername();
-        tokenManager.issueTokens(response, username);
+        Long userId = customUserDetails.getUserId();
+        tokenManager.issueTokens(response, username, userId);
     }
 
     @Override

--- a/src/main/java/com/matzip/api/matzip_api/global/auth/service/AuthService.java
+++ b/src/main/java/com/matzip/api/matzip_api/global/auth/service/AuthService.java
@@ -49,7 +49,8 @@ public class AuthService {
 
         tokenManager.validateRefreshToken(refreshToken);
         String username = tokenManager.getUsername(refreshToken);
+        Long userId = tokenManager.getUserId(refreshToken);
         tokenManager.deleteRefreshToken(refreshToken);
-        tokenManager.issueTokens(response, username);
+        tokenManager.issueTokens(response, username, userId);
     }
 }

--- a/src/main/java/com/matzip/api/matzip_api/global/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/matzip/api/matzip_api/global/auth/util/JwtTokenProvider.java
@@ -47,16 +47,24 @@ public class JwtTokenProvider {
     }
 
     public String getCategory(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+            .get("category", String.class);
     }
 
-    public String createJwt(String category, String username) {
+    public Long getUserId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+            .get("userId", Long.class);
+    }
+
+    public String createJwt(String category, String username, Long userId) {
         return Jwts.builder()
             .claim("category", category)
             .claim("account", username)
+            .claim("userId", userId)
             .issuedAt(new Date(System.currentTimeMillis()))
             .expiration(new Date(
-                System.currentTimeMillis() + (category.equals("refresh") ? refreshExpiration: accessExpiration)))
+                System.currentTimeMillis() + (category.equals("refresh") ? refreshExpiration
+                    : accessExpiration)))
             .signWith(secretKey)
             .compact();
     }

--- a/src/main/java/com/matzip/api/matzip_api/global/auth/util/TokenManager.java
+++ b/src/main/java/com/matzip/api/matzip_api/global/auth/util/TokenManager.java
@@ -20,10 +20,10 @@ public class TokenManager {
         jwtTokenProvider.validateToken(token);
     }
 
-    public void issueTokens(HttpServletResponse response, String username) {
+    public void issueTokens(HttpServletResponse response, String username, Long userId) {
         // JWT 생성
-        String accessToken = jwtTokenProvider.createJwt("access", username);
-        String refreshToken = jwtTokenProvider.createJwt("refresh", username);
+        String accessToken = jwtTokenProvider.createJwt("access", username, userId);
+        String refreshToken = jwtTokenProvider.createJwt("refresh", username, userId);
 
         // Redis에 Refresh Token 저장
         saveRefreshToken(username, refreshToken);
@@ -52,6 +52,9 @@ public class TokenManager {
 
     public String getUsername(String token) {
         return jwtTokenProvider.getUsername(token);
+    }
+    public Long getUserId(String token){
+        return jwtTokenProvider.getUserId(token);
     }
 
     // Refresh Token Redis에 저장


### PR DESCRIPTION
- JWT 페이로드에 userId 클레임을 추가
- JwtUtil 클래스의 JWT 생성 및 파싱 로직 업데이트

컨트롤러 매개변수에 @AuthenticationPrincipal CustomUserDetails user 를 통해서 userId, account 값을 사용할 수 있습니다.
이전과 JWT 페이로드가 달라졌으므로 새롭게 로그인하여 토큰을 발급하셔야 합니다.