### PR TITLE
Feat: Add 맛집 상세 api 고도화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 	//fileupload
 	implementation 'org.apache.commons:commons-csv:1.11.0'
 
+	//jackson: redis에서 자바 역직렬화 문제 해결 패키지
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/matzip/api/matzip_api/domain/restrt/controller/RestrtController.java
+++ b/src/main/java/com/matzip/api/matzip_api/domain/restrt/controller/RestrtController.java
@@ -32,7 +32,9 @@ public class RestrtController {
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "맛집 상세 정보", description = "맛집의 상세 정보를 조회하며 해당 맛집의 리뷰 정보를 모두 포함합니다.")
     public ResponseEntity<CommonResponse<RestrtDetailResponseDto>> getRestrtDetail(
+        @Parameter(name = "id", description = "조회할 맛집의 ID", required = true, example = "1")
         @PathVariable Long id) {
         CommonResponse<RestrtDetailResponseDto> response = restrtService.getRestrtDetail(id);
         return new ResponseEntity<>(response, HttpStatus.OK);

--- a/src/main/java/com/matzip/api/matzip_api/domain/restrt/controller/RestrtController.java
+++ b/src/main/java/com/matzip/api/matzip_api/domain/restrt/controller/RestrtController.java
@@ -61,5 +61,4 @@ public class RestrtController {
 
         return new ResponseEntity(CommonResponse.ok(message, dtos), HttpStatus.OK);
     }
-
 }

--- a/src/main/java/com/matzip/api/matzip_api/domain/restrt/entity/Restrt.java
+++ b/src/main/java/com/matzip/api/matzip_api/domain/restrt/entity/Restrt.java
@@ -58,5 +58,6 @@ public class Restrt {
     private String restrtNm;
 
     @OneToMany(mappedBy = "restrt", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<Review> reviews = new ArrayList<>();
 }

--- a/src/main/java/com/matzip/api/matzip_api/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/matzip/api/matzip_api/domain/review/dto/ReviewResponseDto.java
@@ -1,5 +1,9 @@
 package com.matzip.api.matzip_api.domain.review.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,5 +19,8 @@ public class ReviewResponseDto {
     private int score;
     private String content;
     private String account;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/matzip/api/matzip_api/global/config/SecurityConfig.java
+++ b/src/main/java/com/matzip/api/matzip_api/global/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
     private final String[] PERMIT_URL_ARRAY = {
         "/v3/api-docs/**", "/swagger-ui/**", "/v3/api-docs", "/swagger-ui.html",
         "/error", "/signup", "/login", "/reissue",
-        "/health-check","/sgg/**"
+        "/health-check","/sgg/**","/restrt/**"
     };
     private final ObjectMapper objectMapper;
     private final AuthenticationConfiguration authenticationConfiguration;


### PR DESCRIPTION
- 맛집 상세 조회 시 Redis를 사용한 캐싱 기능을 추가하여 성능 최적화
- 맛집 데이터는 캐시에서 조회 가능하며, 없는 경우 DB에서 조회 후 캐시에 저장
- 단, 리뷰가 1개 이상일 경우에만 캐시에 저장하도록 조건 추가

#### ++
- reviews 필드에 @Builder.Default 어노테이션을 사용해 초기화 값을 빌더 패턴에 반영되도록 수정해 빌드 오류 해결
- 맛집 상세 정보 API Swagger 문서화

이슈 #8 을 을 해결합니다.